### PR TITLE
implement WriteAs for Borrow type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //! let mut buf = Vec::new();
 //!
 //! // write &[T] (T: Serialize) as a CSV into a Writer
-//! x.as_slice().write_as(CSV, &mut buf).unwrap();
+//! x.write_as(CSV, &mut buf).unwrap();
 //! assert_eq!(buf, csv.as_bytes());
 //! ```
 //!


### PR DESCRIPTION
fixes #16 by implementing `WriteAs` for `A: Borrow<F::Input<T>>` rather than `F::Input<T>`.

This makes `WriteAs` be implemented for any type which can be borrowed into the format's input.